### PR TITLE
[snippy] Unify instructions weights in histogram verification

### DIFF
--- a/llvm/test/tools/llvm-snippy/histogram-weight-not-double.yaml
+++ b/llvm/test/tools/llvm-snippy/histogram-weight-not-double.yaml
@@ -33,4 +33,4 @@ histogram:
     - [LW, 10.0]
     - [SW, 10.0]
 
-# CHECK: error: MUL is given with incorrect weight: '1.0_o' can't be converted to double
+# CHECK: error: incorrect weight specified for MUL: '1.0_o' can't be converted to double

--- a/llvm/test/tools/llvm-snippy/incorrect-weight-error.yaml
+++ b/llvm/test/tools/llvm-snippy/incorrect-weight-error.yaml
@@ -42,4 +42,4 @@ histogram:
     - [SUB, 1.0]
     - [BEQ, 1.0]
 
-# CHECK: error: ADDI is given with incorrect weight: 'INCORRECT_WEIGHT_VALUE' should be a positive double value
+# CHECK: error: incorrect weight specified for ADDI: got 'INCORRECT_WEIGHT_VALUE' while expecting a non-negative double value

--- a/llvm/test/tools/llvm-snippy/rvv-config-biased/err-rvv-negative-weights-vl.yaml
+++ b/llvm/test/tools/llvm-snippy/rvv-config-biased/err-rvv-negative-weights-vl.yaml
@@ -18,4 +18,4 @@ sections:
 histogram:
     - [VADD_VV, 1.0]
 
-# CHECK: VL/VM: weights must be non-negative!
+# CHECK: error: incorrect weight specified for max_encodable: got '-1.0' while expecting a non-negative double value

--- a/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Config/OpcodeHistogram.h
@@ -23,7 +23,6 @@
 #include "llvm/Support/Error.h"
 
 #include <algorithm>
-#include <cmath>
 #include <cstddef>
 #include <iterator>
 #include <map>
@@ -408,24 +407,6 @@ struct OpcodeHistogramNormalization final {
                                   double Weight);
 
 private:
-  static Expected<double> parseWeight(StringRef WeightStr) {
-    auto Weight = 0.0;
-    auto ParseFailure = WeightStr.getAsDouble(Weight, true);
-    if (ParseFailure) {
-      return makeFailure(
-          snippy::Errc::InvalidArgument,
-          formatv("'{}' can't be converted to double", WeightStr));
-    }
-    auto IncorrectWeightValue =
-        (std::isnan(Weight) || std::isinf(Weight) || Weight < 0.0);
-    if (IncorrectWeightValue) {
-      return makeFailure(
-          snippy::Errc::InvalidArgument,
-          formatv("'{}' should be a positive double value", WeightStr));
-    }
-    return Weight;
-  }
-
   static void duplicateInstructionMsg(LLVMContext &LLVMCtx,
                                       StringRef NameOfDuplicatedInstruction) {
     // 'snippy::warn' and 'snippy::notice' are separated to split the message

--- a/llvm/tools/llvm-snippy/include/snippy/Support/Utils.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/Utils.h
@@ -15,6 +15,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 
 #include <array>
+#include <cmath>
 #include <set>
 #include <type_traits>
 
@@ -453,6 +454,11 @@ template <typename T> void normalizeValues(T &&RangeOrContainer) {
   normalizeValues(llvm::adl_begin(RangeOrContainer),
                   llvm::adl_end(RangeOrContainer));
 }
+
+inline bool isValidWeight(double Weight) {
+  return !(std::isnan(Weight) || std::isinf(Weight) || Weight < 0.0);
+}
+
 } // namespace snippy
 } // namespace llvm
 #endif // LLVM_TOOLS_LLVM_SNIPPY_SUPPORT_UTILS_H

--- a/llvm/tools/llvm-snippy/include/snippy/Support/YAMLHistogram.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/YAMLHistogram.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_TOOLS_LLVM_SNIPPY_SUPPORT_YAMLHISTOGRAM_H
 #define LLVM_TOOLS_LLVM_SNIPPY_SUPPORT_YAMLHISTOGRAM_H
 
+#include "snippy/Support/DiagnosticInfo.h"
+#include "snippy/Support/Error.h"
 #include "snippy/Support/YAMLUtils.h"
 
 #include "llvm/Support/YAMLTraits.h"
@@ -170,13 +172,12 @@ template <typename T> struct YAMLHistogramNormEntry {
     if constexpr (YAMLHistogramArbitraryValue_v<DenormEntry>) {
       return YAMLHistogramTraits<T>::denormalizeEntry(Io, KeyStr, WeightStr);
     } else {
-      double Weight = 0.0;
-      if (WeightStr.getAsDouble(Weight, true)) {
-        Io.setError(
-            "Incorrect histogram: Weight must be a floating point value");
+      auto Weight = parseWeight(WeightStr);
+      if (!Weight) {
+        Io.setError(incorrectWeightErrorMsg(KeyStr, Weight.takeError()));
         return E;
       }
-      return YAMLHistogramTraits<T>::denormalizeEntry(Io, KeyStr, Weight);
+      return YAMLHistogramTraits<T>::denormalizeEntry(Io, KeyStr, Weight.get());
     }
   }
 

--- a/llvm/tools/llvm-snippy/include/snippy/Support/YAMLUtils.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/YAMLUtils.h
@@ -12,7 +12,9 @@
 #include "snippy/Support/DiagnosticInfo.h"
 #include "snippy/Support/Utils.h"
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
 
@@ -392,6 +394,28 @@ struct has_ScalarTraitsWithStringError // NOLINT
       (sizeof(test<yaml::ScalarTraits<T, void>>(nullptr, nullptr, nullptr)) ==
        1);
 };
+
+inline Expected<double> parseWeight(StringRef WeightStr) {
+  auto Weight = 0.0;
+  auto ParseFailure = WeightStr.getAsDouble(Weight, true);
+  if (ParseFailure)
+    return makeFailure(Errc::InvalidArgument,
+                       formatv("'{}' can't be converted to double", WeightStr));
+  if (isValidWeight(Weight))
+    return Weight;
+  return makeFailure(
+      Errc::InvalidArgument,
+      formatv("got '{}' while expecting a non-negative double value",
+              WeightStr));
+}
+
+inline std::string
+incorrectWeightErrorMsg(StringRef InstructionWithIncorrectWeightName,
+                        Error ErrExplain) {
+  return "incorrect weight specified for " +
+         InstructionWithIncorrectWeightName.str() + ": " +
+         llvm::toString(std::move(ErrExplain));
+}
 
 } // namespace snippy
 

--- a/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
+++ b/llvm/tools/llvm-snippy/lib/Config/OpcodeHistogram.cpp
@@ -99,8 +99,7 @@ OpcodeHistogram OpcodeHistogramNormalization::denormalize(yaml::IO &IO) {
   for (auto &&[NameInfo, WeightStr] : NameWeightSeq) {
     auto Weight = parseWeight(WeightStr);
     if (!Weight) {
-      IO.setError(NameInfo.Val + " is given with incorrect weight: " +
-                  llvm::toString(Weight.takeError()));
+      IO.setError(incorrectWeightErrorMsg(NameInfo.Val, Weight.takeError()));
       break;
     }
 


### PR DESCRIPTION
Hi!
This PR addresses the following issue - #13
# Summary
1) static method `parseWeight` was moved from `struct OpcodeHistogramNormalization` to namespace `llvm::snippy`
2) function `incorrectWeightErrorMsg` was added to unify error message