### PR TITLE
[snippy] Fix `dump-intervals-to-verify` to work with `init-regs-in-elf`

### DIFF
--- a/llvm/test/tools/llvm-snippy/dump-intervals-to-verify-init-regs.yaml
+++ b/llvm/test/tools/llvm-snippy/dump-intervals-to-verify-init-regs.yaml
@@ -1,0 +1,37 @@
+# RUN: llvm-snippy %s -model-plugin=None \
+# RUN:    -mattr=-c,+m \
+# RUN:    -o %t.layout.elf \
+# RUN:    -initial-regs-yaml=%S/initialization/Inputs/histogram_rv64gv.yaml \
+# RUN:    -dump-intervals-to-verify=%t.layout.elf.intervals-to-verify.yaml
+# RUN: FileCheck -input-file=%t.layout.elf.intervals-to-verify.yaml %s
+# RUN: llvm-objdump %t.layout.elf -d |& FileCheck %s --check-prefix=DIS
+
+
+# COM: we expect prologue + init regs size.
+# CHECK: intervals-to-verify:
+# CHECK-NEXT: [ 0xF0, 0x138 ]
+
+# COM: check with disasm that div will start at expected PC, and not div was before.
+# DIS-NOT: ec: {{[0-9a-f]+}} div
+# DIS: f0: {{[0-9a-f]+}} div
+
+options:
+  init-regs-in-elf: on
+  honor-target-abi: on
+  mtriple: riscv64
+  num-instrs: 20
+
+sections:
+    - name:      1
+      VMA:       0x000000
+      SIZE:      0x100000
+      LMA:       0x000000
+      ACCESS:    rx
+    - name:      2
+      VMA:       0x400200000
+      SIZE:      0x1000
+      LMA:       0x400200000
+      ACCESS:    rw
+
+histogram:
+    - [DIV, 1.0]

--- a/llvm/tools/llvm-snippy/lib/PrologueEpilogueInsertionPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/PrologueEpilogueInsertionPass.cpp
@@ -399,7 +399,7 @@ bool PrologueEpilogueInsertion::insertPrologue(
   if (!IsEntry)
     return true;
   auto &SM = InstrGenCtx.getSnippyModule();
-  SM.getOrAddResult<ObjectMetadata>().EntryPrologueInstrCnt =
+  SM.getOrAddResult<ObjectMetadata>().EntryPrologueInstrCnt +=
       std::distance(MBB->begin(), Ins);
   if (SGCtx.getConfig().PassCfg.CodeLayout)
     return true;

--- a/llvm/tools/llvm-snippy/lib/RegsInitInsertionPass.cpp
+++ b/llvm/tools/llvm-snippy/lib/RegsInitInsertionPass.cpp
@@ -110,10 +110,18 @@ bool RegsInitInsertion::runOnMachineFunction(MachineFunction &MF) {
 
   const auto &RegState =
       SGCtx.getProgramContext().getInitialRegisterState(SubTgt);
-  planning::InstructionGenerationContext IGC{
-      *BlockRegsInit, BlockRegsInit->getFirstTerminator(), SGCtx, SimCtx};
+  auto &&Ins = BlockRegsInit->getFirstTerminator();
+  planning::InstructionGenerationContext IGC{*BlockRegsInit, Ins, SGCtx,
+                                             SimCtx};
 
   SnippyTgt.generateRegsInit(IGC, RegState);
+  // Update the prologue size to include all generated instructions.
+  // Depending on the initialization method, the flow might not yet be
+  // reproducible until initialization completes.
+  auto &SM = IGC.getSnippyModule();
+  size_t InitRegsPrologInstrCnt = std::distance(BlockRegsInit->begin(), Ins);
+  SM.getOrAddResult<ObjectMetadata>().EntryPrologueInstrCnt +=
+      InitRegsPrologInstrCnt;
   return true;
 }
 


### PR DESCRIPTION
[snippy] Fix `dump-intervals-to-verify` work with `init-regs-in-elf`