### PR TITLE
[llvm-ie] Fix static archive linking

### DIFF
--- a/llvm/tools/llvm-snippy/llvm-ie/lib/RISCV/CMakeLists.txt
+++ b/llvm/tools/llvm-snippy/llvm-ie/lib/RISCV/CMakeLists.txt
@@ -9,4 +9,5 @@ add_llvm_library(LLVMInstructionEnumeratorRISCV
 
   DEPENDS
   RISCVInstrEnumsTableGen
+  LINK_LIBS PRIVATE LLVMInstructionEnumerator
 )


### PR DESCRIPTION
[llvm-ie] Fix static archive linking

RISCVInstructionEnumerator::enumerateInstructions calls filterByExtensions
which is defined in the LLVMInstructionEnumerator library. Note that there's
no cyclic dependency here because LLVMInstructionEnumerator lib doesn't depend on backend "plugins".