### PR TITLE
[snippy] Fix inconsistency between SnippyX86Target and SnippyTarget

### DIFF
--- a/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/X86/Target.cpp
@@ -106,7 +106,7 @@ public:
     reportUnimplementedError();
   }
 
-  void generateModeChange(const planning::InstructionRequest &ModeChangeInstr,
+  void generateModeChange(const ModeChangingContext &MCC,
                           InstructionGenerationContext &IGC,
                           MDNode *MetadataMark) const override {
     reportUnimplementedError();


### PR DESCRIPTION
\[snippy\] Fix inconsistency between SnippyX86Target and SnippyTarget

One of the previous patches modified SnippyTarget and its implementations for RISCV and AArch64, but not for X86. This patch fixes SnippyX86Target.