### PR TITLE
[snippy] Changing the order of vector operands selection from EEW to size of the register group

### DIFF
--- a/llvm/test/tools/llvm-snippy/codegen/rvv-register-overlaps/gather.yaml
+++ b/llvm/test/tools/llvm-snippy/codegen/rvv-register-overlaps/gather.yaml
@@ -34,6 +34,10 @@ histogram:
   - [VRGATHER_VV, 1.0]
   - [VRGATHEREI16_VV, 1.0]
 
+# COM: Check that vd group cannot overlap with source groups.
+# CHECK-NOT: $v20 = VRGATHEREI16_VV $v20
+# CHECK-NOT: $v24 = VRGATHEREI16_VV $v24
+# CHECK-NOT: $v28 = VRGATHEREI16_VV $v28
 # COM: Check that vs1 group can overlap with vs2 group (if EEW == SEW).
 # CHECK: VRGATHEREI16_VV $v24, $v24
 # COM: Check that vs1 group cannot overlap with vs2 group (if EEW != SEW).

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVGenerated.h
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RISCVGenerated.h
@@ -1626,6 +1626,29 @@ inline bool isRVVFPWidening(unsigned Opcode) {
   }
 }
 
+inline bool isRVVWideningDestOverride(unsigned Opcode) {
+  switch (Opcode) {
+  default:
+    return false;
+  case RISCV::VWMACCU_VV:
+  case RISCV::VWMACCU_VX:
+  case RISCV::VWMACC_VV:
+  case RISCV::VWMACC_VX:
+  case RISCV::VWMACCSU_VV:
+  case RISCV::VWMACCSU_VX:
+  case RISCV::VWMACCUS_VX:
+  case RISCV::VFWMACC_VV:
+  case RISCV::VFWMACC_VF:
+  case RISCV::VFWMSAC_VV:
+  case RISCV::VFWMSAC_VF:
+  case RISCV::VFWNMACC_VV:
+  case RISCV::VFWNMACC_VF:
+  case RISCV::VFWNMSAC_VV:
+  case RISCV::VFWNMSAC_VF:
+    return true;
+  }
+}
+
 inline bool isRVVSemiWidening(unsigned Opcode) {
   switch (Opcode) {
   default:
@@ -1938,7 +1961,7 @@ inline bool isVectorRegClass(int16_t RegClassID) {
 }
 
 inline unsigned getOperandEEW(const MCInstrDesc &InstrDesc, unsigned OpIndex,
-                              unsigned SEW, unsigned VLENB = 0) {
+                              unsigned SEW) {
   auto Opcode = InstrDesc.getOpcode();
   assert(OpIndex < InstrDesc.operands().size());
   auto Operand = InstrDesc.operands()[OpIndex];
@@ -1978,7 +2001,6 @@ inline unsigned getOperandEEW(const MCInstrDesc &InstrDesc, unsigned OpIndex,
   if (isRVVWholeRegLoadStore(Opcode)) {
     // EEW is a data element width.
     assert(OpIndex == 0);
-    assert(VLENB != 0);
     return getLoadStoreNaturalAlignment(Opcode) * CHAR_BIT;
   }
 
@@ -1999,7 +2021,7 @@ inline bool canSrcDestOperandsOverlap(unsigned Opcode) {
   return !(isRVVSetFirstMaskBit(Opcode) || isRVVIndexedSegLoadStore(Opcode) ||
            isRVVIota(Opcode) || isRVVGather(Opcode) || isRVVGather16(Opcode) ||
            isRVVSlide1Up(Opcode) || isRVVSlideUp(Opcode) ||
-           isRVVCompress(Opcode));
+           isRVVCompress(Opcode) || isRVVWideningDestOverride(Opcode));
 }
 
 inline bool canProduceNaN(const MCInstrDesc &InstrDesc) {

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -250,22 +250,6 @@ static snippy::opt<size_t> ReservationSetSize(
     cl::init(64), cl::cat(SnippyRISCVOptions));
 
 namespace {
-static unsigned getDestRegsNum(const MCInstrDesc &InstrDesc,
-                               const MachineBasicBlock &MBB,
-                               const SnippyProgramContext &ProgCtx) {
-  constexpr auto DestIdx = 0u;
-  // Not RVV instruction isn't target specific for selfcheck,
-  // so we provide only one destination register to store
-  if (!isVectorRegClass(InstrDesc.operands()[DestIdx].RegClass))
-    return 1;
-  auto &TgtCtx = ProgCtx.getTargetContext().getImpl<RISCVGeneratorContext>();
-  auto DestRegsMult = TgtCtx.getOperandRegsCount(InstrDesc, DestIdx, MBB);
-  auto Opcode = InstrDesc.getOpcode();
-  if (isRVVSegLoadStore(Opcode))
-    return DestRegsMult * getNumFields(Opcode);
-  return DestRegsMult;
-}
-
 bool isCompressedBranch(unsigned Opcode) {
   return Opcode == RISCV::C_BEQZ || Opcode == RISCV::C_BNEZ;
 }
@@ -1203,8 +1187,8 @@ getVectorSources(const MCInstrDesc &InstrDesc) {
 
 static std::vector<Register> initExcludeResult(unsigned OpIndex) {
   constexpr auto DestIdx = 0u;
-  // We cant overwrite mask register, because the values in the v0 register
-  // must correspond to riscv-vector-unit::mode-distribution::VM.
+  // FIXME: Now we cant overwrite mask register, because the values in the v0
+  // register must correspond to riscv-vector-unit::mode-distribution::VM.
   if (NoMaskModeForRVV || OpIndex == DestIdx)
     return {RISCV::V0};
   return {};
@@ -1215,8 +1199,15 @@ static std::vector<Register> initExcludeResult(unsigned OpIndex,
                                                const LLVMState &State) {
   if (!initExcludeResult(OpIndex).empty())
     return {RISCV::V0};
-  // This means that we will initialize this register in a special way. So we
-  // should forbid V0, since V0 is a mask that should not be overwritten.
+
+  auto Operand = InstrDesc.operands()[OpIndex];
+  // FIXME: We should remove this condition from here when we can overwrite V0.
+  if (isRVVuseV0RegExplicitly(InstrDesc.getOpcode()) &&
+      (Operand.RegClass != RISCV::VMV0RegClassID))
+    return {RISCV::V0};
+
+  // FIXME: This means that we will initialize this register in a special way.
+  // So we should forbid V0, since V0 is a mask that should not be overwritten.
   if (!State.isReinitializableOperand(InstrDesc, OpIndex))
     return {RISCV::V0};
   return {};
@@ -1327,29 +1318,26 @@ excludeForIndexedSegLoad(unsigned OpIndex, InstructionGenerationContext &IGC,
   // For vector indexed segment loads, the destination vector register
   // groups cannot overlap the source vector register group (specified
   // by vs2), else the instruction encoding is reserved.
-  auto AddConstraint = [&](unsigned Idx, unsigned NumFields) {
-    auto RegsCount =
-        TgtCtx.getOperandRegsCount(InstrDesc, Idx, MBB) * NumFields;
+  auto AddConstraint = [&](unsigned Idx) {
+    auto RegsCount = TgtCtx.getOperandRegsCount(InstrDesc, Idx, MBB);
     auto BaseReg = VRegGetter(Idx);
     Result.resize(Result.size() + RegsCount);
     std::iota(Result.end() - RegsCount, Result.end(), BaseReg);
   };
 
   constexpr auto Vs2Idx = 2u;
-  auto SEW = static_cast<unsigned>(TgtCtx.getSEW(MBB));
-  auto VLENB = TgtCtx.getVLENB();
-  auto Vs2EEW = getOperandEEW(InstrDesc, Vs2Idx, SEW, VLENB);
-  auto DestEEW = getOperandEEW(InstrDesc, DestIdx, SEW, VLENB);
+  auto Vs2RegsCount = TgtCtx.getOperandRegsCount(InstrDesc, Vs2Idx, MBB);
+  auto DestRegsCount = TgtCtx.getOperandRegsCount(InstrDesc, DestIdx, MBB);
   if (OpIndex == DestIdx) {
-    // If DestEEW >= Vs2EEW, vs2 not yet preselect.
-    if (DestEEW < Vs2EEW)
-      AddConstraint(Vs2Idx, /* NumFields */ 1u);
+    // If DestRegsCount >= Vs2RegsCount, vs2 not yet preselect.
+    if (DestRegsCount < Vs2RegsCount)
+      AddConstraint(Vs2Idx);
     return Result;
   }
   assert(OpIndex == Vs2Idx);
-  // If DestEEW < Vs2EEW, vd not yet preselect.
-  if (DestEEW >= Vs2EEW)
-    AddConstraint(DestIdx, getNumFields(InstrDesc.getOpcode()));
+  // If DestRegsCount < Vs2RegsCount, vd not yet preselect.
+  if (DestRegsCount >= Vs2RegsCount)
+    AddConstraint(DestIdx);
   return Result;
 }
 
@@ -1369,13 +1357,9 @@ excludeForDest(unsigned OpIndex, InstructionGenerationContext &IGC,
 
   auto AddDestSrcConstraint = [&](unsigned VSrcIdx) {
     auto DestCount = TgtCtx.getOperandRegsCount(InstrDesc, OpIndex, MBB);
-    auto SEW = static_cast<unsigned>(TgtCtx.getSEW(MBB));
-    auto VLENB = TgtCtx.getVLENB();
-    auto VsEEW = getOperandEEW(InstrDesc, VSrcIdx, SEW, VLENB);
-    auto EEW = getOperandEEW(InstrDesc, OpIndex, SEW);
-    // If VsEEW <= EEW, vs2 not yet preselect.
-    if (VsEEW > EEW) {
-      auto VsCount = TgtCtx.getOperandRegsCount(InstrDesc, VSrcIdx, MBB);
+    auto VsCount = TgtCtx.getOperandRegsCount(InstrDesc, VSrcIdx, MBB);
+    // If VsCount < DestCount, vs not yet preselect.
+    if (VsCount > DestCount || (VsCount == DestCount && OpIndex > VSrcIdx)) {
       auto BaseVsReg = VRegGetter(VSrcIdx);
       if (!canSrcDestOperandsOverlap(InstrDesc.getOpcode()))
         Result.push_back(BaseVsReg);
@@ -1450,10 +1434,8 @@ static bool isNecessaryExcludeRegisters(InstructionGenerationContext &IGC,
 
   std::vector<unsigned> OperandEEWs;
   auto SEW = static_cast<unsigned>(TgtCtx.getSEW(MBB));
-  auto VLENB = TgtCtx.getVLENB();
-  transform(Indices, std::back_inserter(OperandEEWs), [&](auto Idx) {
-    return getOperandEEW(InstrDesc, Idx, SEW, VLENB);
-  });
+  transform(Indices, std::back_inserter(OperandEEWs),
+            [&](auto Idx) { return getOperandEEW(InstrDesc, Idx, SEW); });
   // If the opcode is illegal for the current configuration, then all
   // calculations do not make sense and we can select any register for the
   // operand.
@@ -1469,9 +1451,9 @@ static bool isNecessaryExcludeRegisters(InstructionGenerationContext &IGC,
   // If instruction vector operands have identical EEWs, then we don't
   // exclude anything.
   assert(!OperandEEWs.empty());
-  return !all_of(OperandEEWs, [DestEEW = getOperandEEW(
-                                   InstrDesc, /* DestIdx */ 0, SEW, VLENB)](
-                                  auto EEW) { return EEW == DestEEW; }) ||
+  return !all_of(OperandEEWs,
+                 [DestEEW = getOperandEEW(InstrDesc, /* DestIdx */ 0, SEW)](
+                     auto EEW) { return EEW == DestEEW; }) ||
          !canSrcDestOperandsOverlap(Opcode);
 }
 
@@ -1495,14 +1477,17 @@ static std::vector<Register> getExcludedForSources(
     if (OpIndex == SrcIdx)
       SrcIdx = *VSecondSrc;
 
-    auto AnotherEEW = getOperandEEW(InstrDesc, SrcIdx, SEW);
+    auto RegsCount = TgtCtx.getOperandRegsCount(InstrDesc, OpIndex, MBB);
+    auto SrcRegsCount = TgtCtx.getOperandRegsCount(InstrDesc, SrcIdx, MBB);
+    auto SrcEEW = getOperandEEW(InstrDesc, SrcIdx, SEW);
     // A vector register cannot be used to provide source operands with more
     // than one EEW for a single instruction. A mask register source is
     // considered to have EEW=1 for this constraint. An encoding that would
     // result in the same vector register being read with two or more
     // different EEWs, including when the vector register appears at different
     // positions within two or more vector register groups, is reserved.
-    if (AnotherEEW > EEW) {
+    if (SrcEEW != EEW && (SrcRegsCount > RegsCount ||
+                          (SrcRegsCount == RegsCount && OpIndex > SrcIdx))) {
       const auto &RegInfo = State.getRegInfo();
       const auto &Tgt = State.getSnippyTarget();
       auto BaseReg =
@@ -1510,12 +1495,16 @@ static std::vector<Register> getExcludedForSources(
       [[maybe_unused]] const auto &VRegClass =
           RegInfo.getRegClass(RISCV::VRRegClassID);
       assert(VRegClass.contains(BaseReg));
-      auto AnotherRegsCount =
-          TgtCtx.getOperandRegsCount(InstrDesc, SrcIdx, MBB);
-      Result.resize(Result.size() + AnotherRegsCount);
-      std::iota(Result.end() - AnotherRegsCount, Result.end(), BaseReg);
+      Result.resize(Result.size() + SrcRegsCount);
+      std::iota(Result.end() - SrcRegsCount, Result.end(), BaseReg);
     }
   }
+
+  // FIXME: This condition applies only when we select the source register. In
+  // the case of destination register, this requirement can be relaxed (it is
+  // sufficient that the number of dest registers is 1). But since we can't
+  // write to V0 yet, this check doesn't make sense here, but it needs to be
+  // added in the future.
   // Check source-source overlap constraint with V0
   if (isRVVuseV0RegExplicitly(InstrDesc.getOpcode()) && EEW != 1)
     Result.push_back(RISCV::V0);
@@ -1751,7 +1740,8 @@ public:
   std::vector<Register>
   getRegsForSelfcheck(const MachineInstr &MI,
                       InstructionGenerationContext &IGC) const override {
-    const auto &FirstDestOperand = MI.getOperand(0);
+    constexpr auto DestIdx = 0u;
+    const auto &FirstDestOperand = MI.getOperand(DestIdx);
     assert(FirstDestOperand.isReg());
     auto BaseDestRegister = FirstDestOperand.getReg();
     const auto &ProgCtx = IGC.ProgCtx;
@@ -1759,7 +1749,11 @@ public:
     if (isRVVWholeRegisterInstr(MI.getOpcode()))
       BaseDestRegister = State.getSnippyTarget().getFirstPhysReg(
           BaseDestRegister, State.getRegInfo());
-    std::vector<Register> Regs(getDestRegsNum(MI.getDesc(), IGC.MBB, ProgCtx));
+    const auto &TgtCtx =
+        ProgCtx.getTargetContext().getImpl<RISCVGeneratorContext>();
+    auto DestRegsNum =
+        TgtCtx.getOperandRegsCount(MI.getDesc(), DestIdx, IGC.MBB);
+    std::vector<Register> Regs(DestRegsNum);
     std::iota(Regs.begin(), Regs.end(), BaseDestRegister);
     return Regs;
   }
@@ -5105,8 +5099,9 @@ public:
   getSelectionOperandsOrder(InstructionGenerationContext &IGC,
                             const MCInstrDesc &InstrDesc,
                             SmallVectorImpl<unsigned> &Indices) const override {
-    // For vector instructions, we first select the operands that have a large
-    // EEW in order to minimize cases when there are not enough registers.
+    // For vector instructions, we first select the operands in which a larger
+    // number of registers are formed into a register group in order to minimize
+    // cases when there are not enough registers.
     auto NumOperands = InstrDesc.getNumOperands();
     auto &ProgCtx = IGC.ProgCtx;
     const auto &TgtCtx =
@@ -5116,14 +5111,12 @@ public:
     std::iota(Indices.begin(), Indices.end(), 0u);
     if (!TgtCtx.hasActiveRVVMode(MBB))
       return;
-    auto SEW = static_cast<unsigned>(TgtCtx.getSEW(MBB));
-    auto VLENB = TgtCtx.getVLENB();
-    std::vector<unsigned> OperandEEWs;
-    transform(Indices, std::back_inserter(OperandEEWs), [&](auto Idx) {
-      return getOperandEEW(InstrDesc, Idx, SEW, VLENB);
+    std::vector<unsigned> OperandRegsCounts;
+    transform(Indices, std::back_inserter(OperandRegsCounts), [&](auto Idx) {
+      return TgtCtx.getOperandRegsCount(InstrDesc, Idx, MBB);
     });
-    sort(Indices, [&OperandEEWs](auto Idx1, auto Idx2) {
-      return OperandEEWs[Idx1] > OperandEEWs[Idx2];
+    sort(Indices, [&OperandRegsCounts](auto Idx1, auto Idx2) {
+      return OperandRegsCounts[Idx1] > OperandRegsCounts[Idx2];
     });
   }
 
@@ -5141,7 +5134,6 @@ public:
         ProgCtx.getTargetContext().getImpl<RISCVGeneratorContext>();
     auto &MBB = IGC.MBB;
     auto RCID = RC.getID();
-
     if (InstrDesc.getOperandConstraint(OpIndex, MCOI::TIED_TO) >= 0)
       return {};
     if (isSPRelative(Opcode))
@@ -5170,7 +5162,6 @@ public:
       return {};
 
     auto SEW = static_cast<unsigned>(TgtCtx.getSEW(MBB));
-    auto VLENB = TgtCtx.getVLENB();
     if (RCID == RISCV::VMV0RegClassID)
       return excludeForVMV0RegClass(OpIndex, InstrDesc, SEW,
                                     PregeneratedOperands, GetVReg);
@@ -5179,7 +5170,7 @@ public:
     if (!isNecessaryExcludeRegisters(IGC, InstrDesc))
       return Result;
 
-    // 1. Check source-source overlap constraint
+    // 1. Check operand-sources overlaps constraints
     copy(getExcludedForSources(InstrDesc, OpIndex, IGC, PregeneratedOperands),
          std::back_inserter(Result));
     if (InstrDesc.mayStore())
@@ -5187,7 +5178,7 @@ public:
     if (isRVVIndexedSegLoadStore(Opcode))
       return excludeForIndexedSegLoad(OpIndex, IGC, InstrDesc, Result, GetVReg);
 
-    // 2. Check destination-sources overlap constraints
+    // 2. Check operand-destination overlap constraint
     constexpr auto DestIdx = 0u;
     if (OpIndex == DestIdx)
       return excludeForDest(OpIndex, IGC, InstrDesc, Result, GetVReg);
@@ -5196,12 +5187,14 @@ public:
       return Result;
 
     // Here we separately process all three relations between DestEEW and EEW.
-    auto DestEEW = getOperandEEW(InstrDesc, DestIdx, SEW, VLENB);
-    auto EEW = getOperandEEW(InstrDesc, OpIndex, SEW, VLENB);
-    if (DestEEW < EEW) {
+    auto DestCount = TgtCtx.getOperandRegsCount(InstrDesc, DestIdx, MBB);
+    auto Count = TgtCtx.getOperandRegsCount(InstrDesc, OpIndex, MBB);
+    if (DestCount < Count) {
       // vd not yet preselected
       return Result;
     }
+    auto DestEEW = getOperandEEW(InstrDesc, DestIdx, SEW);
+    auto EEW = getOperandEEW(InstrDesc, OpIndex, SEW);
     if (DestEEW > EEW)
       return excludeIfDestEEWBiggerEEW(OpIndex, IGC, InstrDesc, Result,
                                        GetVReg);
@@ -6319,15 +6312,18 @@ SnippyRISCVTarget::getRegClass(const InstructionGenerationContext &IGC,
       (OperandRegClassID != RISCV::VRRegClassID))
     return RegInfo.getRegClass(OperandRegClassID);
 
-  auto RegsCount = TgtCtx.getOperandRegsCount(InstrDesc, OpIndex, MBB);
+  auto [RegNumMult, IsFractional] =
+      TgtCtx.getOperandEMUL(InstrDesc, OpIndex, MBB);
+  if (IsFractional)
+    RegNumMult = 1;
   // Special handling for Vector Load/Store Segment Instructions, because
   // this instructions moves subarrays.
   if ((isRVVUnitStrideSegLoadStore(Opcode) ||
        isRVVStridedSegLoadStore(Opcode) || isRVVIndexedSegLoadStore(Opcode)) &&
       OpIndex == 0 /* vector destination register group */)
-    return getRVVSegLoadStoreRegClassForVd(Opcode, RegsCount, RegInfo);
+    return getRVVSegLoadStoreRegClassForVd(Opcode, RegNumMult, RegInfo);
 
-  switch (RegsCount) {
+  switch (RegNumMult) {
   case 1:
     return RegInfo.getRegClass(OperandRegClassID);
   case 2:

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/TargetGenContext.h
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/TargetGenContext.h
@@ -207,6 +207,14 @@ public:
     auto SEW = static_cast<unsigned>(getSEW(MBB));
     constexpr std::pair<unsigned, bool> EMUL1 = {/* Multiplier */ 1,
                                                  /* IsFractional */ false};
+
+    auto EEW = getOperandEEW(InstrDesc, OpIndex, SEW);
+    // riscv-v-spec-1.0: For the purpose of determining register group overlap
+    // constraints, mask elements have EEW=1. A vector mask occupies only one
+    // vector register regardless of SEW and LMUL (=> EMUL = 1).
+    if (EEW == 1)
+      return EMUL1;
+
     // riscv-v-spec-1.0: Scalar operands can be taken from element 0 of a vector
     // register (.vs suffix denotes the second operand is a scalar stored in
     // element 0 of a vector register). Any vector register can be used to hold
@@ -284,22 +292,23 @@ public:
 
     if (isRVVWholeRegisterInstr(Opcode))
       return std::make_pair(getRVVWholeRegisterCount(Opcode), 0);
-
-    auto EEW = getOperandEEW(InstrDesc, OpIndex, SEW);
-    // riscv-v-spec-1.0: For the purpose of determining register group overlap
-    // constraints, mask elements have EEW=1. A vector mask occupies only one
-    // vector register regardless of SEW and LMUL (=> EMUL = 1).
-    if (EEW == 1)
-      return EMUL1;
-
     return computeDecodedEMUL(ELEN, SEW, EEW, LMUL);
   }
 
   unsigned getOperandRegsCount(const MCInstrDesc &InstrDesc, unsigned OpIndex,
                                const MachineBasicBlock &MBB) const {
+    assert(OpIndex < InstrDesc.operands().size());
+    auto Operand = InstrDesc.operands()[OpIndex];
+    auto OperandRegClassID = Operand.RegClass;
+    if (!isVectorRegClass(OperandRegClassID))
+      return 1;
+
     auto [Multiplier, IsFractional] = getOperandEMUL(InstrDesc, OpIndex, MBB);
     if (IsFractional)
-      return 1;
+      Multiplier = 1;
+    auto Opcode = InstrDesc.getOpcode();
+    if (isRVVSegLoadStore(Opcode) && OpIndex == 0)
+      return Multiplier * getNumFields(Opcode);
     return Multiplier;
   }
 


### PR DESCRIPTION
\[snippy\] Changing the order of vector operands selection from EEW to size of the register group

Now the vector operands are selected not in the order of decreasing EEW, but in the order of decreasing the size of the register group. This helps to avoid more errors related to the lack of vector registers.