### PR TITLE
[snippy] Exclude rvv modes without available opcodes from generation

### DIFF
--- a/llvm/test/tools/llvm-snippy/Inputs/rvv-sections.yaml
+++ b/llvm/test/tools/llvm-snippy/Inputs/rvv-sections.yaml
@@ -1,0 +1,16 @@
+sections:
+  - name:      1
+    VMA:       0x210000
+    SIZE:      0x100000
+    LMA:       0x210000
+    ACCESS:    rx
+  - name:      2
+    VMA:       0x80000000
+    SIZE:      0x100000
+    LMA:       0x80000000
+    ACCESS:    rw
+  - name:      3
+    VMA:       0x100000
+    LMA:       0x100000
+    SIZE:      0x100000
+    ACCESS:    r

--- a/llvm/test/tools/llvm-snippy/burst/rvv/err-suitable-config.yaml
+++ b/llvm/test/tools/llvm-snippy/burst/rvv/err-suitable-config.yaml
@@ -39,7 +39,8 @@ burst:
 
 histogram:
   - ["V[LS][OU]XEI64_V", 1.0]
-
+  - [ADDI, 1.0]
+  
 # COM: There is no suitable rvv configuration here because all values of EMUL
 # COM: (EMUL = (EEW/SEW)*LMUL) are greater than 8 => illegal instruction
 # CHECK: error: Can't find suitable RVV configuration for burst group

--- a/llvm/test/tools/llvm-snippy/codegen/rvv-no-available-instrs-pvill.yaml
+++ b/llvm/test/tools/llvm-snippy/codegen/rvv-no-available-instrs-pvill.yaml
@@ -36,4 +36,5 @@ histogram:
     - [VXOR_VX, 1.0]
     - [VZEXT_VF4, 1.0]
 
-# CHECK: We can not create any primary instruction in this context.
+# CHECK: error: Incorrect RVV setup: there are none opcodes available for all RVV modes
+

--- a/llvm/test/tools/llvm-snippy/codegen/rvv-no-available-instrs.yaml
+++ b/llvm/test/tools/llvm-snippy/codegen/rvv-no-available-instrs.yaml
@@ -25,4 +25,5 @@ sections:
 histogram:
     - [VSEXT_VF8, 1.0]
 
-# CHECK: We can not create any primary instruction in this context.
+# CHECK: error: Incorrect RVV setup: there are none opcodes available for all RVV modes
+

--- a/llvm/test/tools/llvm-snippy/codegen/rvv-not-all-modes-are-available.yaml
+++ b/llvm/test/tools/llvm-snippy/codegen/rvv-not-all-modes-are-available.yaml
@@ -1,0 +1,28 @@
+# RUN: llvm-snippy %s |& FileCheck %s
+
+options:
+  mtriple: riscv64
+  mattr: +v
+  num-instrs: 1 
+
+include:
+  - ../Inputs/rvv-sections.yaml
+  - Inputs/rvv-unit-all.yaml
+
+histogram:
+    - [VFADD_VF, 1.0]
+
+# CHECK: warning: (no-available-opcode-for-context) No opcodes are available to be generated in the following RVV modes. These modes will be deleted from generation:
+# CHECK: [SEW: e8, LMUL: m1, VL: 0-16]
+# CHECK: [SEW: e8, LMUL: m2, VL: 0-32]
+# CHECK: [SEW: e8, LMUL: m4, VL: 0-64]
+# CHECK: [SEW: e8, LMUL: m8, VL: 0-128]
+# CHECK: [SEW: e8, LMUL: mf8, VL: 0-2]
+# CHECK: [SEW: e8, LMUL: mf4, VL: 0-4]
+# CHECK: [SEW: e8, LMUL: mf2, VL: 0-8]
+# CHECK: [SEW: e16, LMUL: m1, VL: 0-8]
+# CHECK: [SEW: e16, LMUL: m2, VL: 0-16]
+# CHECK: [SEW: e16, LMUL: m4, VL: 0-32]
+# CHECK: [SEW: e16, LMUL: m8, VL: 0-64]
+# CHECK: [SEW: e16, LMUL: mf4, VL: 0-2]
+# CHECK: [SEW: e16, LMUL: mf2, VL: 0-4]

--- a/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
+++ b/llvm/tools/llvm-snippy/include/snippy/Support/DiagnosticInfo.h
@@ -52,7 +52,8 @@ namespace snippy {
   WARN_CASE(LoopCountersOnStack, "loop-counters-on-stack")                     \
   WARN_CASE(SMCWithoutEffect, "smc-without-effect")                            \
   WARN_CASE(DeprecatedOption, "deprecated-option")                             \
-  WARN_CASE(DuplicatedInstructions, "duplicated-instructions")
+  WARN_CASE(DuplicatedInstructions, "duplicated-instructions")                 \
+  WARN_CASE(NoAvailableOpcodeForContext, "no-available-opcode-for-context")
 
 #ifdef WARN_CASE
 #error WARN_CASE should not be defined at this point

--- a/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
+++ b/llvm/tools/llvm-snippy/lib/Generator/SnippyModule.cpp
@@ -371,7 +371,7 @@ Expected<OpcGenHolder> DefaultPolicyConfig::createOpcodeGenerator(
                 [&](auto &&Entry) { return OpcMask(Entry.first); });
   OpcodeHistogram DFHCopy(DFHTopOpcodes);
   DFHCopy.copyPatterns(DataFlowHistogram);
-  if (DFHCopy.size() == 0)
+  if (DFHCopy.empty())
     return makeFailure(
         Errc::InvalidConfiguration,
         "We can not create any primary instruction in this "
@@ -379,7 +379,6 @@ Expected<OpcGenHolder> DefaultPolicyConfig::createOpcodeGenerator(
         "snippy can not find any instruction that could be created "
         "in current context.\nTry to increase instruction number by "
         "one or add more instructions to histogram.");
-
   auto &PluginManager = *Common->ProgramCfg.PluginManagerImpl;
   if (PluginManager.pluginHasBeenLoaded())
     return PluginManager.createPlugin(DFHCopy);

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.cpp
@@ -498,7 +498,7 @@ template <> struct GeneratorFactory<VMGeneratorHolder> {
 namespace llvm {
 namespace snippy {
 
-static std::string toString(VSEW SEW) {
+std::string toString(VSEW SEW) {
   switch (SEW) {
   case VSEW::SEWReserved1:
     return "eReserved1";
@@ -517,7 +517,7 @@ static std::string toString(VSEW SEW) {
   llvm_unreachable("Unknown SEW");
 }
 
-static std::string toString(VLMUL LMUL) {
+std::string toString(VLMUL LMUL) {
   switch (LMUL) {
   case VLMUL::LMUL_RESERVED:
     return "mReserved";

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.h
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/RVVUnitConfig.h
@@ -57,6 +57,8 @@ struct LMULEnumList final {
       VLMUL::LMUL_RESERVED, VLMUL::LMUL_F8, VLMUL::LMUL_F4, VLMUL::LMUL_F2};
 };
 
+std::string toString(VLMUL LMUL);
+
 // Note: integer values are in-sync with RVV spec 1.0
 enum class VSEW : unsigned {
   SEW8 = 8,
@@ -74,6 +76,8 @@ struct SEWEnumList final {
                                      VSEW::SEWReserved1, VSEW::SEWReserved2,
                                      VSEW::SEWReserved3, VSEW::SEWReserved4};
 };
+
+std::string toString(VSEW SEW);
 
 enum class VXRMMode : unsigned { RNU = 0, RNE = 1, RDN = 2, RON = 3 };
 struct VXRMEnumList final {

--- a/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
+++ b/llvm/tools/llvm-snippy/lib/Target/RISCV/Target.cpp
@@ -6206,6 +6206,125 @@ static void dumpRvvConfigurationInfo(StringRef FilePath,
     ReportFileError(OS.error());
 }
 
+// There are many configs, which differ only in VL and don't support the
+// same instruction. So, to avoid making the warning message enormous, we need
+// data structure to squash RVVConfigs by VL.
+using VLSquasher = std::set<unsigned>;
+using RVVConfigSquasher = std::map<SewLmulPair, VLSquasher>;
+
+static std::string toString(const std::pair<SewLmulPair, VLSquasher> &Cfg) {
+  std::string Str;
+  raw_string_ostream RSO{Str};
+  const auto &SewLmul = Cfg.first;
+  RSO << "[SEW: " << toString(std::get<VSEW>(SewLmul))
+      << ", LMUL: " << snippy::toString(std::get<VLMUL>(SewLmul)) << ", VL: ";
+  const auto &VLSquash = Cfg.second;
+  assert(!VLSquash.empty());
+  // squash 1,2,3,4,5 into 1-5
+  // and separate these ranges with ,
+  for (auto It = VLSquash.begin(), Ite = VLSquash.end();;) {
+    RSO << *It;
+    auto Last =
+        std::adjacent_find(It, Ite, [](unsigned First, unsigned Second) {
+          return (First + 1) != Second;
+        });
+    if (Last == Ite) {
+      if (auto LastPrev = std::prev(Last); LastPrev != It)
+        RSO << "-" << *LastPrev;
+      break;
+    }
+    if (Last != It)
+      RSO << "-" << *Last;
+    It = std::next(Last);
+    RSO << ", ";
+  }
+  RSO << "]";
+  return Str;
+}
+
+// Exclude configs without available opcodes and return true, if there is at
+// least one config with at least one available opcode, otherwise return false.
+static bool excludeConfigsWithoutAvailableOpcodes(
+    const RVVPrimaryConfigGenerator &CfgGen, RVVConfigSquasher &CfgSquasher,
+    LLVMContext &Ctx, const OpcodeHistogram::TopOpcodesType &Hist,
+    const RISCVSubtarget &ST, unsigned VLEN) {
+  auto Probabilities = CfgGen.Dist.probabilities();
+  // The Probabilieties array can be large. Avoid copying when it's not used.
+  auto ProbabilitiesChanged = false;
+  auto AvailableConfigs = false;
+  for (size_t I = 0, E = Probabilities.size(); I < E; ++I) {
+    if (isZero(Probabilities[I]))
+      continue;
+    auto PrimaryCfg = CfgGen.idxToConfig(I);
+    auto AtLeastOneAvailableOpcode =
+        llvm::any_of(Hist, [&PrimaryCfg, &ST, VLEN](const auto &Opc) {
+          auto IsOpcodeAvailable =
+              !isRVV(Opc.first) ||
+              isLegalRVVInstr(Opc.first, PrimaryCfg, VLEN, &ST);
+          return IsOpcodeAvailable;
+        });
+    if (AtLeastOneAvailableOpcode) {
+      AvailableConfigs = true;
+      continue;
+    }
+    // exclude configs from generation, because it
+    // doesn't have available opcodes
+    Probabilities[I] = 0.0;
+    ProbabilitiesChanged = true;
+    CfgSquasher[{PrimaryCfg.SEW, PrimaryCfg.LMUL}].insert(PrimaryCfg.VL);
+  }
+  if (ProbabilitiesChanged && AvailableConfigs)
+    CfgGen.Dist = std::discrete_distribution<unsigned>(Probabilities.begin(),
+                                                       Probabilities.end());
+  return AvailableConfigs;
+}
+
+static void processAndFilterRVVConfigs(LLVMContext &Ctx, const Config &Cfg,
+                                       const TargetSubtargetInfo *STI,
+                                       const RVVConfigurationInfo &VUInfo) {
+  // exclude PrimaryConfigs which haven't available opcodes
+  const auto &ST = static_cast<const RISCVSubtarget &>(*STI);
+  const auto &Hist = Cfg.getOpcodeHistogram().topOpcodes();
+  auto VLEN = VUInfo.getVLEN();
+
+  RVVConfigSquasher ConfigSquasher;
+  auto ExcludeConfigs =
+      [&ConfigSquasher, &Ctx, &Hist, &ST, VLEN](
+          const std::optional<RVVPrimaryConfigGenerator> &Generator) -> bool {
+    return (Generator.has_value()
+                ? excludeConfigsWithoutAvailableOpcodes(
+                      *Generator, ConfigSquasher, Ctx, Hist, ST, VLEN)
+                : false);
+  };
+
+  const auto &CfgGen = VUInfo.getGenInfoPtr()->CfgGen;
+  const auto &PrimaryGen = CfgGen.PrimaryGen;
+  const auto &PrimaryGenReduced = CfgGen.PrimaryGenReduced;
+  // We need these temporary variables (AvailableConfigsPrimaryGen and
+  // AvailableConfigsPrimaryGenReduced) because the || operator performs lazy
+  // evaluation. This means we cannot call ExcludeConfigs directly within the
+  // expression, as the method must exclude configurations that lack available
+  // opcodes in both generators.
+  auto AvailableConfigsInPrimaryGen = ExcludeConfigs(PrimaryGen);
+  auto AvailableConfigsInPrimaryGenReduced = ExcludeConfigs(PrimaryGenReduced);
+  auto AvailableConfigs =
+      AvailableConfigsInPrimaryGen || AvailableConfigsInPrimaryGenReduced;
+  if (!AvailableConfigs)
+    snippy::fatal(Ctx, "Incorrect RVV setup",
+                  "there are none opcodes available for all RVV modes");
+  for (const auto &ExcludedConfig : ConfigSquasher) {
+    auto ManyCfgs = (ExcludedConfig.second.size() > 1);
+    snippy::warn(
+        snippy::WarningName::NoAvailableOpcodeForContext, Ctx,
+        llvm::formatv(
+            "No opcodes are available to be generated in the following "
+            "RVV mode{}. {} mode{} will be deleted from generation",
+            (ManyCfgs ? "s" : ""), (ManyCfgs ? "These" : "This"),
+            (ManyCfgs ? "s" : "")),
+        llvm::formatv("\n{}", toString(ExcludedConfig)));
+  }
+}
+
 static void checkThatRVVInitModeSupportsReinit(const OpcodeHistogram &Hist) {
   auto IsRVVOpcode = [](auto &&Opc) -> bool { return isRVV(Opc); };
 
@@ -6258,6 +6377,9 @@ SnippyRISCVTarget::createTargetContext(LLVMState &State, const Config &Cfg,
       std::move(RISCVCfg), matchRVVOpcodesWithDisallowedIntersectingAccesses(
                                Cfg.Histogram, State.getInstrInfo()));
   const auto &VUInfo = RGC->getVUConfigInfo();
+
+  if (VUInfo.isRVVEnabled())
+    processAndFilterRVVConfigs(State.getCtx(), Cfg, STI, VUInfo);
 
   if (DumpRVVConfigurationInfo.isSpecified())
     dumpRvvConfigurationInfo(/*FilePath=*/DumpRVVConfigurationInfo.getValue(),


### PR DESCRIPTION
\[snippy\] Exclude rvv modes without available opcodes from generation

Previously, RVV modes lacking suitable opcodes were not excluded from the generation process. If such a mode was selected for generation, an error occurred; otherwise, Snippy successfully generated a code snippet (meaning that, given the same input parameters, Snippy could either produce an error or successfully generate a snippet).

Since this patch, such modes are excluded prior to generation, and the situation is classified as a warning.

If no suitable modes are found it's an error.

In order to bring back legacy behavior, the "-Werror=no-available-opcode-for-context" option can be used.