### PR TITLE
[snippy][test] fix sanitizer testing

### DIFF
--- a/llvm/test/tools/llvm-snippy/lit.local.cfg
+++ b/llvm/test/tools/llvm-snippy/lit.local.cfg
@@ -8,11 +8,17 @@ from lit.llvm.subst import FindTool
 SnippyModel = lit_config.params.get('snippy-test-model', 'None')
 Seed = lit_config.params.get('snippy-seed', '1')
 
-if SnippyModel == 'None':
-  config.available_features.add('riscv-rvv')
-
+if config.llvm_use_sanitizer:
+  # Run only tests without model on sanitizer build
+  # FIXME: disable spike-based tests here and explicitly add
+  # "riscv-snippy-model-None" to disable "UNSUPPORTED: riscv-snippy-model-None"
+  # This should be handled differently to avoid running same tests 4 times under
+  # sanitizer
+  config.available_features.discard("riscv-snippy-model-spike")
+  config.available_features.add("riscv-snippy-model-None")
+  SnippyModel = "None"
+config.available_features.add('riscv-rvv')
 if SnippyModel in ('spike'):
-  config.available_features.add('riscv-rvv')
   config.available_features.add('riscv-snippy-model-callbacks')
 config.available_features.add(f"riscv-snippy-model-{SnippyModel}")
 


### PR DESCRIPTION
[snippy][test] fix sanitizer testing

Snippy uses RTLD_DEEPBIND for model dlopen call so model usage is not
supported with sanitizers