### PR TITLE
[snippy][packaging] Fix whisper in release bundle

### DIFF
--- a/llvm/tools/llvm-snippy/nix/snippy-release-tarball.nix
+++ b/llvm/tools/llvm-snippy/nix/snippy-release-tarball.nix
@@ -18,12 +18,22 @@ let
         ];
       }
       ''
+        shopt -s extglob
+
         mkdir $out
         cd $out
         mkdir {bin,lib}
 
-        cp -v ${llvm-snippy.out}/bin/* ./bin/
+        cp -v ${llvm-snippy.out}/bin/!(*.so) ./bin/
+        modelPlugins=( ${llvm-snippy.out}/bin/*-plugin.so )
         cp -v ${wrap-buddy}/lib/wrap-buddy/loader.bin ./lib/loader.bin
+
+        for modelPath in "''${modelPlugins[@]}"; do
+          model=$(basename $modelPath)
+          cp -v $modelPath ./lib/
+          chmod +x "./lib/$model"
+          ln -vsr "./lib/$model" "./bin/$model"
+        done
 
         ldd ./bin/* 2>/dev/null | awk '$1~/^\//{print $1} $3~/^\//{print $3}' | sort -u | while IFS= read -r lib; do
           [ -f "$lib" ] && cp -L --remove-destination -v "$lib" ./lib/

--- a/llvm/tools/llvm-snippy/package.nix
+++ b/llvm/tools/llvm-snippy/package.nix
@@ -101,10 +101,10 @@ stdenv.mkDerivation (finalAttrs: {
   '';
   checkPhase = ''
     runHook preCheck
-    export LIT_OPTS="-v --no-progress-bar"
-    cmake --build . --target check-llvm-tools-llvm-snippy
-    export LIT_OPTS="-v --no-progress-bar -Dsnippy-test-model=spike"
-    cmake --build . --target check-llvm-tools-llvm-snippy
+    for model in "None" "spike"; do
+      export LIT_OPTS="-v --no-progress-bar -Dsnippy-test-model=$model"
+      cmake --build . --target check-llvm-tools-llvm-snippy
+    done
     runHook postCheck
   '';
 


### PR DESCRIPTION
Whishper wasn't being properly patchelf-d and libz wasn't vendored:

`error: could not load library: libz.so.1: cannot open shared object file: No such file or directory`

With spike we got lucky because all it depends on is already in the closure loaded by llvm-snippy.